### PR TITLE
Fix an error on Android

### DIFF
--- a/game/__main__.py
+++ b/game/__main__.py
@@ -18,7 +18,10 @@ import logging
 import os
 import pathlib
 
-logging.basicConfig(filename=os.path.join(str(pathlib.Path.home()), ".what-the-hex.log"), level=logging.INFO)
+try:
+    logging.basicConfig(filename=os.path.join(str(pathlib.Path.home()), ".what-the-hex.log"), level=logging.INFO)
+except PermissionError:
+    print("We can't use this path on Android, FIXME")
 
 # Note, I think Toga is actually running as the main package in Briefcase,
 # so this import style is necessary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,6 @@ requires = [
 
 [tool.briefcase.app.game.android]
 requires = [
+    "rubicon-java",
     "toga-android==0.3.0.dev16"
 ]


### PR DESCRIPTION
I think Android support is probably not going to happen any time soon.
After fixing these issues, the Python interpreter is able to successfully start,
but it seems pygame.base was either not added or does not work.

Once pygame has upstream support for Android and works flawlessly, this may be
worth revisiting. For now, no dice.

Still, these changes should happen.